### PR TITLE
- accept address array input in graph ql instead of simple array

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,28 +1,46 @@
 const UNISWAP_V3_SUBGRAPH_ID = {
-  ETHEREUM: '5zvR82QoaXYFyDEKLZ9t6v9adgnptxYpKpSbxtgVENFV',
-  POLYGON: '3hCPRGf4z88VC5rsBKU5AA9FBBq5nF3jbKJG7VZCbhjm',
-  BASE: '43Hwfi3dJSoGpyas9VwNoDAv55yjgGrPpNSmbQZArzMG',
-  CELO: 'ESdrTJ3twMwWVoQ1hUE2u7PugEHX3QkenudD6aXCkDQ4',
-  OPTIMISM: 'Cghf4LfVqPiFw6fp6Y5X5Ubc8UpmUhSfJL82zwiBFLaj',
-  ARBITRUM: 'FbCGRftH4a3yZugY7TnbYgPJVEv2LvMT6oF1fxPe9aJM'
-} as const;
+  ETHEREUM: "5zvR82QoaXYFyDEKLZ9t6v9adgnptxYpKpSbxtgVENFV",
+  POLYGON: "3hCPRGf4z88VC5rsBKU5AA9FBBq5nF3jbKJG7VZCbhjm",
+  BASE: "43Hwfi3dJSoGpyas9VwNoDAv55yjgGrPpNSmbQZArzMG",
+  CELO: "ESdrTJ3twMwWVoQ1hUE2u7PugEHX3QkenudD6aXCkDQ4",
+  OPTIMISM: "Cghf4LfVqPiFw6fp6Y5X5Ubc8UpmUhSfJL82zwiBFLaj",
+  ARBITRUM: "FbCGRftH4a3yZugY7TnbYgPJVEv2LvMT6oF1fxPe9aJM"
+} as const
 
-const UNISWAP_V3_BASE_URL = `https://gateway.thegraph.com/api/${process.env.PLASMO_PUBLIC_UNISWAP_API_KEY}`;
-const TOKEN_LOGO_BASE_URL = `https://github.com/trustwallet/assets/tree/master/blockchains`;
+const UNISWAP_V3_BASE_URL = `https://gateway.thegraph.com/api/${process.env.PLASMO_PUBLIC_UNISWAP_API_KEY}`
+const TOKEN_LOGO_BASE_URL = `https://github.com/trustwallet/assets/tree/master/blockchains`
 
-export const getUniswapV3GraphlUrl = (network: keyof typeof UNISWAP_V3_SUBGRAPH_ID) => {
-  const subgraphId = UNISWAP_V3_SUBGRAPH_ID[network];
+export const getUniswapV3GraphlUrl = (
+  network: keyof typeof UNISWAP_V3_SUBGRAPH_ID
+) => {
+  const subgraphId = UNISWAP_V3_SUBGRAPH_ID[network]
   return `${UNISWAP_V3_BASE_URL}/subgraphs/id/${subgraphId}`
 }
 
 // ToDo: token address must be checksummed
-export const getTokenIconUrl = (network: keyof typeof UNISWAP_V3_SUBGRAPH_ID, token_address: string) =>{
+export const getTokenIconUrl = (
+  network: keyof typeof UNISWAP_V3_SUBGRAPH_ID,
+  token_address: string
+) => {
   return `${TOKEN_LOGO_BASE_URL}/${network.toLowerCase()}/assets/${token_address}/logo.png`
 }
 
+export const getBrianPrompt = (
+  inputToken: string, // default should always be "ETH"
+  outputToken: string, // ticker symbol of output token or token contract address
+  inputNetwork: keyof typeof UNISWAP_V3_SUBGRAPH_ID, // default should be network we deposit on -> BASE? 
+  outputNetwork: keyof typeof UNISWAP_V3_SUBGRAPH_ID, // if the copied trade happened on the same network as inputNetwork, we use outputNetwork===inputNetwork
+  inputAmount: number // absolute amount you want to buy -> example 0.001 (if you want to buy 0.001ETH worth of outputToken)
+) => {
+  if (inputNetwork===outputNetwork) {
+    return `Swap ${inputAmount} of ${inputToken} to ${outputToken} on ${inputNetwork}`
+  }
+  return`Crosschain swap ${inputAmount} of ${inputToken} on ${inputNetwork} to ${outputToken} on ${outputNetwork}`
+}
+
 export const GRAPH_QL_QUERY = `
-query Swaps($address: String!) {
-  swaps(where: { origin: $address }) {
+query Swaps($addresses: [String]!) {
+  swaps(where: { origin_in: $addresses }) {
     id
     transaction {
       id
@@ -50,4 +68,4 @@ query Swaps($address: String!) {
     logIndex
   }
 }
-`;
+`


### PR DESCRIPTION
Allows to filter for `origin` in the return statement just so we can request trades from all followed addresses at once